### PR TITLE
fixed dependency to System.Net.Http on mono .net 4.5

### DIFF
--- a/NuGet.CommandLine/App.config
+++ b/NuGet.CommandLine/App.config
@@ -17,6 +17,10 @@
         <assemblyIdentity name="NuGet.Client.BaseTypes" publicKeyToken="2e465378e3b1a8dd" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-0.1.9.0" newVersion="0.1.9.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
System.IO.FileNotFoundException: Could not load file
or assembly or one of its dependencies. File name:
'System.Net.Http, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
