### PR TITLE
Add build logic to the command line repo and improve MEF handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 [Rr]eleases/
 x64/
 x86/
-build/
 bld/
 [Bb]in/
 [Oo]bj/
@@ -134,6 +133,8 @@ publish/
 *.nupkg
 # The packages folder can be ignored because of Package Restore
 **/packages/*
+**/.nuget/*
+**/nupkgs/*
 # except build/, which is used as an MSBuild target.
 !**/packages/build/
 # If using the old MSBuild-Integrated Package Restore, uncomment this:

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,3 @@
+@echo off
+if "%VisualStudioVersion%"=="" call %VS2012CommandPromptBat%
+msbuild build\build.msbuild %*

--- a/build/build.msbuild
+++ b/build/build.msbuild
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+      <RootDir>$(MSBuildStartupDirectory)</RootDir>
+    </PropertyGroup>
+    <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+       <ParameterGroup>
+           <OutputFilename ParameterType="System.String" Required="true" />
+       </ParameterGroup>
+       <Task>
+           <Reference Include="System.Core" />
+           <Using Namespace="System" />
+           <Using Namespace="System.IO" />
+           <Using Namespace="System.Net" />
+           <Using Namespace="Microsoft.Build.Framework" />
+           <Using Namespace="Microsoft.Build.Utilities" />
+           <Code Type="Fragment" Language="cs">
+               <![CDATA[
+               try {
+                   OutputFilename = Path.GetFullPath(OutputFilename);
+
+                   Log.LogMessage("Downloading latest version of NuGet.exe...");
+                   WebClient webClient = new WebClient();
+                   webClient.DownloadFile("https://nuget.org/nuget.exe", OutputFilename);
+
+                   return true;
+               }
+               catch (Exception ex) {
+                   Log.LogErrorFromException(ex);
+                   return false;
+               }
+           ]]>
+           </Code>
+       </Task>
+    </UsingTask>
+
+    <Target Name="RestorePackages">
+        <ItemGroup>
+            <!-- Package sources used to restore packages. By default will used the registered sources under %APPDATA%\NuGet\NuGet.Config -->
+            <PackageSource Include="$(NUGET_PUSH_TARGET)" Condition="'$(NUGET_PUSH_TARGET)' != ''" />
+            <PackageSource Include="https://www.nuget.org/api/v2" />
+            <PackageSource Include="https://www.myget.org/F/nugetbuild/" />
+            <PackageSource Include="e:\git\consolidation\nupkgs" />
+        </ItemGroup>
+        <PropertyGroup>
+            <NuGetExeDir>$(RootDir)\.nuget</NuGetExeDir>
+            <NuGetExePath>$(NuGetExeDir)\nuget.exe</NuGetExePath>
+            <RestoreCommand>$(NuGetExePath) restore -Source "@(PackageSource)" "@(SolutionFile)" -NonInteractive</RestoreCommand>
+        </PropertyGroup>
+        <MakeDir Directories="$(NuGetExeDir)" Condition="!Exists('$(NuGetExeDir)')" />
+        <Message Text="Restoring packages ... " Importance="high" />
+        <DownloadNuGet OutputFilename="$(NuGetExePath)" Condition=" !Exists('$(NuGetExePath)')" />
+        <Exec Command="$(RestoreCommand)" LogStandardErrorAsError="true" />
+    </Target>
+
+    <Target Name="CheckForMultipleSolutions">
+      <Error Text="Multiple solutions exist in $(RepositoryRoot)!" Condition="'@(SolutionFile->Count())' &gt; 1" />
+    </Target>
+
+    <ItemGroup>
+      <!-- tests -->
+	  <!--TestProjects Include="$(RootDir)\test\PackageManagement.Test\PackageManagement.Test.csproj" /-->
+    </ItemGroup>
+
+    <Target Name="RunTests" Condition=" '$(DisableRunningUnitTests)' != 'true' ">        
+      <MsBuild Projects="@(TestProjects)" Targets="RunTests" BuildInParallel="$(BuildTestsInParallel)" />
+    </Target>
+
+    <Target Name="ReportFxCopResults">
+      <ItemGroup>
+        <FxCopOutputItems Include="$(RootDir)\**\*.dll.CodeAnalysisLog.xml" />
+      </ItemGroup>
+    </Target>
+
+    <Target Name="Clean">
+      <MSBuild Projects="$(RootDir)\NuGet.CommandLine.sln" Targets="Clean" />
+    </Target>
+
+    <ItemGroup>
+      <SolutionFile Include="$(RootDir)\NuGet.CommandLine.sln" />
+    </ItemGroup>
+
+    <Target Name="BuildSln">
+      <PropertyGroup>
+        <EnableCodeAnalysis Condition="'$(EnableCodeAnalysis)' == ''" >true</EnableCodeAnalysis>
+      </PropertyGroup>
+      <MSBuild Projects="@(SolutionFile)" Targets="Build" Properties="EnableCodeAnalysis=$(EnableCodeAnalysis)" />
+    </Target>
+
+    <Target Name="Build" DependsOnTargets="Clean;CheckForMultipleSolutions;RestorePackages;BuildSln;ReportFxCopResults;RunTests" />
+</Project>

--- a/build/sign.targets
+++ b/build/sign.targets
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="Exists($(NUGET_PFX_PATH))">
+	<SignAssembly>true</SignAssembly>
+	<AssemblyOriginatorKeyFile>$(NUGET_PFX_PATH)</AssemblyOriginatorKeyFile>
+    <DelaySign>$(NUGET_DELAYSIGN)</DelaySign>
+  </PropertyGroup>
+</Project>

--- a/build/test.targets
+++ b/build/test.targets
@@ -1,0 +1,16 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<UsingTask AssemblyFile="$(MSBuildStartupDirectory)\tools\xunit\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit" />
+<Target Name="RunTests">
+	<ItemGroup>
+		<Line Include="&lt;configuration&gt;&lt;appSettings&gt;
+&lt;add key=&quot;TargetDir&quot; value=&quot;$(TargetDir)&quot;/&gt;
+&lt;/appSettings&gt;&lt;/configuration&gt;" />
+		</ItemGroup>
+	<WriteLinesToFile
+		File="$(TargetDir)$(AssemblyName).dll.config"
+		Lines="@(Line)"			
+		Overwrite="true"
+		/> 
+    <xunit Assembly="$(TargetDir)$(AssemblyName).dll" />
+</Target>
+</Project>

--- a/pack.ps1
+++ b/pack.ps1
@@ -1,0 +1,131 @@
+param (
+    [string]$PushTarget=$env:NUGET_PUSH_TARGET,
+    [ValidateSet("debug", "release")][string]$Configuration="release",
+    [switch]$SkipTests,
+    [switch]$SkipBuild,
+    [string]$PFXPath,
+    [switch]$DelaySign,
+    [switch]$Stable,
+    [string]$Version
+)
+
+$Id = "NuGet.CommandLine"
+
+# build
+if (!$SkipBuild)
+{
+    if ($SkipTests)
+    {
+        $env:DisableRunningUnitTests="true"
+    }
+    else
+    {
+        $env:DisableRunningUnitTests="false"
+    }
+
+    if ($PFXPath)
+    {
+        $env:NUGET_PFX_PATH=$PFXPath
+
+        if ($DelaySign)
+        {
+            $env:NUGET_DELAYSIGN="true"
+        }
+    }
+
+    Write-Host "Building! configuration: $Configuration" -ForegroundColor Cyan
+    Start-Process "cmd.exe" "/c build.cmd /p:Configuration=$Configuration" -Wait -NoNewWindow
+    Write-Host "Build complete! configuration: $Configuration" -ForegroundColor Cyan
+}
+
+# assembly containing the release file version to use for the package
+$workingDir = (Get-Item -Path ".\" -Verbose).FullName;
+
+# read settings.xml for repo specific settings
+[xml]$xml = Get-Content "settings.xml"
+$projectPathSetting = Select-Xml "/nupkgs/nupkg[@id='$Id']/csprojPath" $xml | % { $_.Node.'#text' } | Select-Object -first 1
+$primaryAssemblySetting = Select-Xml "/nupkgs/nupkg[@id='$Id']/exeName" $xml | % { $_.Node.'#text' } | Select-Object -first 1
+
+# build the csproj and dll full paths
+$projectPath = Join-Path $workingDir $projectPathSetting
+$projectRoot = Split-Path -parent $projectPath
+$primaryAssemblyDir = Join-Path $projectRoot "\bin\$Configuration"
+$primaryAssemblyPath = Join-Path $primaryAssemblyDir $primaryAssemblySetting
+
+Write-Host "Project: $projectPath"
+Write-Host "Target: $primaryAssemblyPath"
+
+# check signature
+Write-Host "Signature check" -ForegroundColor Cyan
+$snPath = Join-Path ${env:ProgramFiles(x86)} "Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\x64\sn.exe"
+Start-Process $snPath "-Tp $primaryAssemblyPath" -Wait -NoNewWindow
+
+# find the current git branch
+$gitBranch = "ci"
+
+git branch | foreach {
+    if ($_ -match "^\*(.*)") {
+        $gitBranch = $matches[1].Trim()
+    }
+}
+
+# prerelease labels can have a max length of 20
+# shorten the branch to 8 chars if needed
+if ($gitBranch.Length -gt 8) {
+    $gitBranch = $gitBranch.SubString(0, 8)
+}
+
+Write-Host "Git branch: $gitBranch" 
+
+if (!$Version) {
+    # find the release version from the target assembly
+    $version = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($primaryAssemblyPath).FileVersion
+
+    if (!$version) {
+        Write-Error "Unable to find the file version!"
+        exit 1
+    }
+
+    $now = [System.DateTime]::UtcNow
+
+    # (git branch)-(last digit of the year)(day of year)(hour)(minute)
+    $version = $version.TrimEnd('0').TrimEnd('.')
+
+    if (!$Stable)
+    {
+        # prerelease labels can have a max length of 20
+        $now = [System.DateTime]::UtcNow
+        $version += "-" + $now.ToString("pre-yyyyMMddHHmmss")
+
+        if ($Configuration -eq "debug")
+        {
+            $version += "-d"
+        }
+    }
+}
+
+Write-Host "Package version: $version" -ForegroundColor Cyan
+
+# create the output folder
+if ((Test-Path nupkgs) -eq 0) {
+    New-Item -ItemType directory -Path nupkgs | Out-Null
+}
+
+# Pack
+.\.nuget\nuget.exe pack $projectPath -Properties configuration=$Configuration -symbols -OutputDirectory nupkgs -version $version
+
+# Find the path of the nupkg we just built
+$nupkgPath = Get-ChildItem .\nupkgs -filter "*$version.nupkg" | % { $_.FullName }
+
+Write-Host $nupkgPath -ForegroundColor Cyan
+
+if ($PushTarget)
+{
+    Write-Host "Pushing: $nupkgPath" -ForegroundColor Cyan
+    # use nuget.exe setApiKey <key> before running this
+    .\.nuget\nuget.exe push $nupkgPath -source $PushTarget
+}
+else
+{
+    Write-Warning "Package not uploaded. Specify -PushTarget to upload this package"
+}

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,6 @@
+<nupkgs>
+	<nupkg id="NuGet.CommandLine">
+		<csprojPath>\src\NuGet.CommandLine\NuGet.CommandLine.csproj</csprojPath>
+		<exeName>NuGet.exe</exeName>
+	</nupkg>
+</nupkgs>

--- a/src/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.CommandLine/Common/Console.cs
@@ -346,6 +346,11 @@ namespace NuGet.CommandLine.Common
             }
         }
 
+        public void ReportError(string message)
+        {
+            Log(MessageLevel.Error, message, new object[0]);
+        }
+
         public void Log(MessageLevel level, string message, params object[] args)
         {
             var oldColor = System.Console.ForegroundColor;

--- a/src/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -197,6 +197,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\build\sign.targets" />
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
     <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />

--- a/src/NuGet.CommandLine/NuGet.CommandLine.nuspec
+++ b/src/NuGet.CommandLine/NuGet.CommandLine.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>NuGet.CommandLine</id>
+    <version>1.0.0-overrideme</version>
+    <title>NuGet's client executable.</title>
+    <authors>NuGet</authors>
+    <copyright>Copyright Outercurve Foundation. All rights reserved.</copyright>
+    <owners>NuGet</owners>
+    <projectUrl>https://github.com/NuGet/NuGet.Configuration/</projectUrl>
+    <licenseUrl>https://raw.githubusercontent.com/NuGet/NuGet.Configuration/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>NuGet's client executable.</description>
+    <tags>nuget configuration nuget.config</tags>
+  </metadata>
+</package>

--- a/src/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.CommandLine/Program.cs
@@ -6,10 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
+using System.ComponentModel.Composition.Primitives;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace NuGet.CommandLine
 {
@@ -26,8 +28,6 @@ namespace NuGet.CommandLine
 
         [Import]
         public ICommandManager Manager { get; set; }
-
-     
 
         /// <summary>
         /// Flag meant for unit tests that prevents command line extensions from being loaded.
@@ -156,20 +156,123 @@ namespace NuGet.CommandLine
 
         private void Initialize(IConsole console)
         {
-            using (var catalog = new AggregateCatalog())
-            {
-                catalog.Catalogs.Add(new AssemblyCatalog(GetType().Assembly));
-                catalog.Catalogs.Add(new DirectoryCatalog(Environment.CurrentDirectory, "*.dll"));
-                
-                if (!IgnoreExtensions)
-                {
-                    AddExtensionsToCatalog(catalog, console);
-                }
+            var assemblies = new List<string>();
+            assemblies.Add(GetType().Assembly.Location);
+            assemblies.AddRange(Directory.EnumerateFiles(AppDomain.CurrentDomain.BaseDirectory, "*.dll"));
 
-                var container = new CompositionContainer(catalog);
-                container.ComposeExportedValue<IConsole>(console);
-                container.ComposeParts(this);
+            if (!IgnoreExtensions)
+            {
+                AddExtensionsToCatalog(assemblies, console);
             }
+
+            var catalog = CreateCatalog(assemblies, console);
+            var container = new CompositionContainer(catalog);
+            container.ComposeExportedValue<IConsole>(console);
+            container.ComposeParts(this);
+        }
+
+
+        /// <summary>
+        /// Creates a catalog for the assemblies
+        /// </summary>
+        /// <param name="assemblyFiles">the assemblies to include in the catalog</param>
+        /// <returns>the catalog containing parts from the assemblies</returns>
+        public static ComposablePartCatalog CreateCatalog(IReadOnlyList<string> assemblyFiles, IConsole console)
+        {
+            AggregateCatalog result = new AggregateCatalog();
+            var nameSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var filename in assemblyFiles)
+            {
+                // skip files we've already seen
+                if (!nameSet.Add(filename))
+                {
+                    continue;
+                }
+                var assembly = GetOrLoad(filename, console);
+                if (assembly != null)
+                {
+                    var assemblyCatalog = CreateCatalog(assembly, console);
+                    if (assemblyCatalog != null)
+                    {
+                        result.Catalogs.Add(assemblyCatalog);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a catalog for the given assembly
+        /// </summary>
+        /// <param name="assembly">the assembly</param>
+        /// <returns>the catalog containing parts from the assembly</returns>
+        private static ComposablePartCatalog CreateCatalog(Assembly assembly, IConsole console)
+        {
+            IEnumerable<Type> types;
+
+            try
+            {
+                ComposablePartCatalog result = new AssemblyCatalog(assembly);
+
+                if (result == null)
+                {
+                    return null;
+                }
+                // Trigger the loading of the assembly.  This will catch on class of error where
+                // other supporting assemblies are missing.
+                result.Any();
+                return result;
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                types = e.Types;
+                console.WriteWarning(e.Message);
+            }
+
+            // In the event there was a problem press on and create a catalog with all types we could
+            // load.  Note however that we have to go further and try to get the imports/exports as doing
+            // that will completely exercise the MEF loading pass.  Any types that can load all their imports
+            // and exports are added to a catalog and included in the container.
+            var loadableTypes = new List<Type>();
+            foreach (var type in types.Where(t => t != null))
+            {
+                try
+                {
+                    foreach (var tempCatalog in new TypeCatalog(type))
+                    {
+                        // Trigger loading exceptions now rather than later.
+                        var dummy1 = tempCatalog.ExportDefinitions.Any();
+                        var dummy2 = tempCatalog.ImportDefinitions.Any();
+                    }
+                    loadableTypes.Add(type);
+                }
+                catch (Exception e)
+                {
+                    e.RethrowIfCritical();
+                    // In most cases this will be irrelevant problems but it is possible that there is a real problem.
+                    console.WriteWarning(e.Message);
+                }
+            }
+
+            return new TypeCatalog(loadableTypes);
+        }
+
+        private static Assembly GetOrLoad(string assembly, IConsole console)
+        {
+            try
+            {
+                AssemblyName name = AssemblyName.GetAssemblyName(assembly);
+                name.CodeBase = assembly;
+                return Assembly.Load(name);
+            }
+            catch (Exception e)
+            {
+                e.RethrowIfCritical();
+                console.WriteWarning(e.Message);
+            }
+            return null;
         }
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We don't want to block the exe from usage if anything failed")]
@@ -196,7 +299,7 @@ namespace NuGet.CommandLine
                    command.Arguments.Count <= attribute.MaxArgs;
         }
 
-        private static void AddExtensionsToCatalog(AggregateCatalog catalog, IConsole console)
+        private static void AddExtensionsToCatalog(List<string> assemblies, IConsole console)
         {
             IEnumerable<string> directories = new[] { ExtensionsDirectoryRoot };
 
@@ -213,7 +316,7 @@ namespace NuGet.CommandLine
                 if (Directory.Exists(directory))
                 {
                     files = Directory.EnumerateFiles(directory, "*.dll", SearchOption.AllDirectories);
-                    RegisterExtensions(catalog, files, console);
+                    RegisterExtensions(assemblies, files, console);
                 }
             }
 
@@ -222,16 +325,16 @@ namespace NuGet.CommandLine
             // Consequently, we'll use a convention - only binaries ending in the name Extensions would be loaded. 
             var nugetDirectory = Path.GetDirectoryName(typeof(Program).Assembly.Location);
             files = Directory.EnumerateFiles(nugetDirectory, "*Extensions.dll");
-            RegisterExtensions(catalog, files, console);
+            RegisterExtensions(assemblies, files, console);
         }
 
-        private static void RegisterExtensions(AggregateCatalog catalog, IEnumerable<string> enumerateFiles, IConsole console)
+        private static void RegisterExtensions(List<string> assemblies, IEnumerable<string> enumerateFiles, IConsole console)
         {
             foreach (var item in enumerateFiles)
             {
                 try
                 {
-                    catalog.Catalogs.Add(new AssemblyCatalog(item));
+                    assemblies.Add(item);
                 }
                 catch (BadImageFormatException ex)
                 {

--- a/src/NuGet.CommandLine/Utility/ExceptionUtility.cs
+++ b/src/NuGet.CommandLine/Utility/ExceptionUtility.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Threading;
 
 namespace NuGet.CommandLine
 {
@@ -25,6 +26,41 @@ namespace NuGet.CommandLine
             }
 
             return exception;
+        }
+
+        public static void RethrowIfCritical(this Exception e)
+        {
+            if (e != null && IsCriticalException(e))
+            {
+                e.Rethrow();
+            }
+        }
+
+        /// <summary>
+        /// Determines if an exception is critical and should not be caught.
+        /// </summary>
+        /// <param name="e">The exception.</param>
+        /// <returns>True if the exception should not be caught.</returns>
+        public static bool IsCriticalException(this Exception e)
+        {
+            return e is StackOverflowException
+                  || e is OutOfMemoryException
+                  || e is ThreadAbortException
+                  || e is ThreadInterruptedException
+                  || e is AccessViolationException
+                  || e is NullReferenceException;
+        }
+
+        /// <summary>
+        /// Rethrows an exception, preserving its original call stack.
+        /// </summary>
+        /// <param name="e">The exception.</param>
+        public static void Rethrow(this Exception e)
+        {
+            if (e != null)
+            {
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(e).Throw();
+            }
         }
     }
 }


### PR DESCRIPTION
With these changes the CommandLine repo can now build (via pack.ps1) like the other repos.
Also, included are changes to the MEF catalog loading that make it more resilient to loading issues in the dlls being consulted.
Finally, there is a tweak to where the assemblies are discovered. Previously they were only looking in Environment.CurrentDirectory.  Now we look in the location beside the .exe.
